### PR TITLE
FIX Issue #104

### DIFF
--- a/Classes/ViewHelpers/DateTime/IndexOnDayViewHelper.php
+++ b/Classes/ViewHelpers/DateTime/IndexOnDayViewHelper.php
@@ -31,6 +31,7 @@ class IndexOnDayViewHelper extends AbstractViewHelper
      */
     public function render(\DateTime $day, Index $index = null, $indices = [], $modification = '')
     {
+        $day = DateTimeUtility::normalizeDateTimeSingle($day->format('d.m.Y'));
         $baseDay = clone $day;
         if ($modification != '') {
             $baseDay->modify($modification);


### PR DESCRIPTION
IndexUtility::isIndexInRange make wrong compares if the Datetimes dont have the same timezone. 
This thread (http://stackoverflow.com/questions/33035497/php-comparing-two-datetime-objects-with-different-timezones) says that a timezone diffrence should not be the problem when we compare 2 Datetimes, but if i debug inside the code, i got that:
IndexStart
DateTime prototype object (2016-11-11T00:00:00+01:00, 1478818800) is <= (rangeEnd) DateTime prototype object (2016-11-10T23:59:59+00:00, 1478822399)
If we look the timestamps, the code is right but the php behavior should be diffrent. 
Anyway if we have 2 Datetimes with the same timezone it works fine.